### PR TITLE
Fix header link path

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -92,7 +92,7 @@ const Header: React.FC = () => {
             <Nav open={menuOpen}>
               <NavButton to="/">プロジェクト</NavButton>
               <NavButton to="#">清算</NavButton>
-              <NavButton to="/projects/${projectId}/receipts">レシート</NavButton>
+              <NavButton to={`/projects/${projectId}/receipts`}>レシート</NavButton>
               <NavButton to="#">支出</NavButton>
             </Nav>
           </>


### PR DESCRIPTION
## Summary
- fix dynamic project link for Receipt page in header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68458b970c50832c88e2447d15c2e945